### PR TITLE
Xf/404 in priorities update

### DIFF
--- a/app/controllers/teacher/priorities_controller.rb
+++ b/app/controllers/teacher/priorities_controller.rb
@@ -20,7 +20,11 @@ class Teacher::PrioritiesController < Teacher::BaseController
     .update_all(priority: false)
 
     table.each do |id, att|
-      Student.find(id).update!(priority: (att >= @threshold))
+      begin
+        Student.find(id).update!(priority: (att >= @threshold))
+      rescue ActiveRecord::RecordNotFound => e; end
+
+      # some student's listed in last semester's attendance rolls may have been deleted - that's totally acceptable
     end
 
     redirect_to teacher_home_path, notice: "Student priorities have been reset."

--- a/app/controllers/teacher/sections_controller.rb
+++ b/app/controllers/teacher/sections_controller.rb
@@ -76,7 +76,7 @@ class Teacher::SectionsController < Teacher::BaseController
       # Previously, we included :event_time above, which cause rails to auto-parse it and interpret it in the current time zone.
       # However, it uses the attached date fields (which is just an empty placeholder) to determine whether to use daylight savings,
       # which leads to times being off-by-one for half the year. We just want to take the raw hour and minute and leave the rest
-      sp[:event_time] = Time.new(1, 1, 1, params.require(:event_group)["event_time(4i)"], params.require(:event_group)["event_time(5i)"], 0)
+      sp[:event_time] = Time.zone.local(1, 1, 1, params.require(:event_group)["event_time(4i)"], params.require(:event_group)["event_time(5i)"], 0)
 
       sp
     end

--- a/app/controllers/teacher/sections_controller.rb
+++ b/app/controllers/teacher/sections_controller.rb
@@ -76,7 +76,7 @@ class Teacher::SectionsController < Teacher::BaseController
       # Previously, we included :event_time above, which cause rails to auto-parse it and interpret it in the current time zone.
       # However, it uses the attached date fields (which is just an empty placeholder) to determine whether to use daylight savings,
       # which leads to times being off-by-one for half the year. We just want to take the raw hour and minute and leave the rest
-      sp[:event_time] = Time.new(0, 0, 0, params.require(:event_group)["event_time(4i)"], params.require(:event_group)["event_time(4i)"], 0)
+      sp[:event_time] = Time.new(1, 1, 1, params.require(:event_group)["event_time(4i)"], params.require(:event_group)["event_time(5i)"], 0)
 
       sp
     end

--- a/app/controllers/teacher/sections_controller.rb
+++ b/app/controllers/teacher/sections_controller.rb
@@ -71,6 +71,13 @@ class Teacher::SectionsController < Teacher::BaseController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def section_params
-      params.require(:event_group).permit(:wday, :event_time, :course_id, :capacity)
+      sp = params.require(:event_group).permit(:wday, :course_id, :capacity)
+
+      # Previously, we included :event_time above, which cause rails to auto-parse it and interpret it in the current time zone.
+      # However, it uses the attached date fields (which is just an empty placeholder) to determine whether to use daylight savings,
+      # which leads to times being off-by-one for half the year. We just want to take the raw hour and minute and leave the rest
+      sp[:event_time] = Time.new(0, 0, 0, params.require(:event_group)["event_time(4i)"], params.require(:event_group)["event_time(4i)"], 0)
+
+      sp
     end
 end

--- a/app/models/event_group.rb
+++ b/app/models/event_group.rb
@@ -25,6 +25,7 @@ class EventGroup < ApplicationRecord
   end
 
   #TODO: remove EventGroup#name entirely - it's stupid
+  # deprecate it and create a notification channel to see if it's ever used?
   def name
     self.course.description
   end

--- a/app/views/teacher/courses/show.html.erb
+++ b/app/views/teacher/courses/show.html.erb
@@ -2,7 +2,7 @@
 <h4>
   <%= I18n.l @course.semester.start %> to <%= I18n.l @course.semester.end %>
 </h4>
-<h4>Currently <%= @course.semester.state_description %></h4>
+<h4><%= @course.semester.state_description %></h4>
 
 <br/>
 

--- a/app/views/teacher/sections/_form.html.erb
+++ b/app/views/teacher/sections/_form.html.erb
@@ -39,6 +39,6 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit (section.persisted? : "Update section" ? "Create section") %>
+    <%= f.submit (section.persisted? ? "Update section" : "Create section") %>
   </div>
 <% end %>

--- a/app/views/teacher/sections/_form.html.erb
+++ b/app/views/teacher/sections/_form.html.erb
@@ -39,6 +39,6 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit %>
+    <%= f.submit "Create section" %>
   </div>
 <% end %>

--- a/app/views/teacher/sections/_form.html.erb
+++ b/app/views/teacher/sections/_form.html.erb
@@ -39,6 +39,6 @@
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Create section" %>
+    <%= f.submit (section.persisted? : "Update section" ? "Create section") %>
   </div>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module MathCircle
     # -- all .rb files in that directory are automatically loaded.
 
     config.time_zone = 'Eastern Time (US & Canada)'
-    config.active_record.default_timezone = :local
+    config.active_record.default_timezone = 'Eastern Time (US & Canada)'
     config.active_record.time_zone_aware_types = [:datetime, :time]
 
     config.action_mailer.default_url_options = { :host => 'localhost' }

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module MathCircle
     # -- all .rb files in that directory are automatically loaded.
 
     config.time_zone = 'Eastern Time (US & Canada)'
-    config.active_record.default_timezone = 'Eastern Time (US & Canada)'
+    config.active_record.default_timezone = :local
     config.active_record.time_zone_aware_types = [:datetime, :time]
 
     config.action_mailer.default_url_options = { :host => 'localhost' }


### PR DESCRIPTION
Three changes:

- the enrollment-priority updater tool errors out if it has an attendance record for a nonexistent student. Since it's perfectly legitimate for a parent to delete student records form the database, `ActiveRecord::NotFound` errors are expected and should not interrupt the work
- timezones were being mismatched between ActiveRecord (which was using local server time) and the frontend, which should always display in EST regardless of user location (because all Emory MC events take place in Atlanta!)
- switched section form text from "Create Event group" to "Create Section" to hide weird model name from the frontend